### PR TITLE
Add support to raw arguments

### DIFF
--- a/src/prompt.h
+++ b/src/prompt.h
@@ -3,6 +3,7 @@
 #define MAX_STR_SIZE 512
 #define MAX_CMD_OPTS 5
 #define INVALID_CMD -1
+#define RAW_ARG -2
 
 struct Option {
     char key[MAX_STR_SIZE];
@@ -10,8 +11,13 @@ struct Option {
     char value[MAX_STR_SIZE];
 };
 
+// binary [cmd || bin_arg] [opts]
 struct Prompt {
     int cmd;
+
+    int has_raw_arg;
+    char raw_arg[MAX_STR_SIZE];
+
     int opts_sz;
     struct Option opts[MAX_CMD_OPTS];
 };


### PR DESCRIPTION
In `libprompt`, a raw argument is an argument that is passed directly to the binary program:

```
$ trash ./Downloads/doc.pdf
```

In this case, `libprompt` will not handle the argument.